### PR TITLE
fix version message

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,15 +16,15 @@ func main() {
 }
 
 //goland:noinspection GoBoolExpressions
-func buildVersion() string {
-	result := version
+func buildVersion() (result string) {
+	result = version
 
 	if commit != "" {
-		result = fmt.Sprintf("%s\ncommit: %s", result, commit)
+		result += fmt.Sprintf("\ncommit: %s", commit)
 	}
 
 	if date != "" {
-		result = fmt.Sprintf("%s\ndate: %s", result, date)
+		result += fmt.Sprintf("\ndate: %s", date)
 	}
 
 	return result


### PR DESCRIPTION
The versioning is stored and committed within a variable. As soon as the variable date is set, the commit number is not taken over into the versions overview, because it is overwritten directly again.

The PR solves the problem and adds both if it was defined.