### PR TITLE
Update GitHub Action CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,8 @@
-name: Go
+name: Go Test
 on:
   push:
-    tags:
-      - v*
+    branches: [ main ]
+  pull_request:
 
 jobs:
   build:
@@ -33,15 +33,3 @@ jobs:
 
       - name: Test
         run: go test -v ./...
-
-      - name: Build
-        run: go build -v .
-
-      - name: Run goreleaser in release mode
-        if: success() && startsWith(github.ref, 'refs/tags/v')
-        uses: goreleaser/goreleaser-action@v2
-        with:
-          version: latest
-          args: release --rm-dist
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/go.mod
+++ b/go.mod
@@ -1,20 +1,35 @@
 module github.com/NETWAYS/check_microsoft365
 
-go 1.16
+go 1.17
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.13.0
-	github.com/Azure/azure-sdk-for-go/sdk/internal v0.9.0 // indirect
 	github.com/NETWAYS/go-check v0.2.0
-	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
-	github.com/microsoft/kiota/abstractions/go v0.0.0-20220201092916-896e79b2ca52 // indirect
 	github.com/microsoft/kiota/authentication/go/azure v0.0.0-20220201092916-896e79b2ca52
+	github.com/microsoftgraph/msgraph-sdk-go v0.7.0
+	github.com/spf13/cobra v1.3.0
+)
+
+require (
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v0.9.0 // indirect
+	github.com/AzureAD/microsoft-authentication-library-for-go v0.4.0 // indirect
+	github.com/cjlapao/common-go v0.0.18 // indirect
+	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
+	github.com/google/uuid v1.3.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/microsoft/kiota/abstractions/go v0.0.0-20220201092916-896e79b2ca52 // indirect
 	github.com/microsoft/kiota/http/go/nethttp v0.0.0-20220201092916-896e79b2ca52 // indirect
 	github.com/microsoft/kiota/serialization/go/json v0.0.0-20220201092916-896e79b2ca52 // indirect
-	github.com/microsoftgraph/msgraph-sdk-go v0.7.0
+	github.com/microsoftgraph/msgraph-sdk-go-core v0.0.5 // indirect
+	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
-	github.com/spf13/cobra v1.3.0
+	github.com/sirupsen/logrus v1.8.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.1 // indirect
 	golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838 // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27 // indirect
+	golang.org/x/text v0.3.7 // indirect
 )


### PR DESCRIPTION
 - Since the binaries are currently huge, we run builds only on tags
 - This can be changed once we reduce the size